### PR TITLE
Updated adjacency matrix creation for monoplex networks

### DIFF
--- a/R/RWRandMatrices.R
+++ b/R/RWRandMatrices.R
@@ -46,107 +46,108 @@
 #'@import iterators
 #'@importFrom methods as
 #'@export
-compute.adjacency.matrix <- function(x,delta = 0.5)
-{
-    if (!isMultiplex(x) & !isMultiplexHet(x)) {
-        stop("Not a Multiplex or Multiplex Heterogeneous object")
+compute.adjacency.matrix <- function(x,delta = 0.5) {
+  if (!isMultiplex(x) && !isMultiplexHet(x)) {
+    stop("Not a Multiplex or Multiplex Heterogeneous object")
+  }
+  if (delta > 1 || delta <= 0) {
+    stop("Delta should be between 0 and 1")
+  }
+
+  N <- x$Number_of_Nodes_Multiplex
+  L <- x$Number_of_Layers
+
+  Layers_Names <- names(x)[seq(L)]
+
+  counter <- 0
+  Layers_List <- lapply(x[Layers_Names],function(x){
+
+    counter <- counter + 1
+    if (is_weighted(x)) { 
+      Adjacency_Layer <- as_adjacency_matrix(x, sparse = TRUE, attr = "weight")
+    } else {
+      Adjacency_Layer <- as_adjacency_matrix(x, sparse = TRUE)
     }
-    if (delta > 1 || delta <= 0) {
-        stop("Delta should be between 0 and 1")
-    }
-    cl <- makeCluster(detectCores())
 
-    N <- x$Number_of_Nodes_Multiplex
-    L <- x$Number_of_Layers
-    
-    ## We impose delta=0 in the monoplex case.
-    if (L==1){
-        delta = 0
-    }
-    
-    Layers_Names <- names(x)[seq(L)]
-    ## IDEM_MATRIX.
-    Idem_Matrix <- Matrix::Diagonal(N, x = 1)
- 
-    counter <- 0 
-    Layers_List <- lapply(x[Layers_Names],function(x){
-        
-        counter <<- counter + 1;    
-        if (is_weighted(x)){ 
-            Adjacency_Layer <-  as_adjacency_matrix(x,sparse = TRUE, 
-                attr = "weight")
-        } else {
-            Adjacency_Layer <-  as_adjacency_matrix(x,sparse = TRUE)
-        }
-        
-        Adjacency_Layer <- Adjacency_Layer[order(rownames(Adjacency_Layer)),
-            order(colnames(Adjacency_Layer))]
-        colnames(Adjacency_Layer) <- 
-            paste0(colnames(Adjacency_Layer),"_",counter)
-        rownames(Adjacency_Layer) <- 
-            paste0(rownames(Adjacency_Layer),"_",counter)
+    Adjacency_Layer <- Adjacency_Layer[order(rownames(Adjacency_Layer)),
+      order(colnames(Adjacency_Layer))]
+    colnames(Adjacency_Layer) <-
+      paste0(colnames(Adjacency_Layer), "_", counter)
+    rownames(Adjacency_Layer) <-
+      paste0(rownames(Adjacency_Layer), "_", counter)
 
-        Adjacency_Layer
-    })
-    
-    MyColNames <- unlist(lapply(Layers_List, function (x) unlist(colnames(x))))
-    MyRowNames <- unlist(lapply(Layers_List, function (x) unlist(rownames(x))))
-    names(MyColNames) <- c()
-    names(MyRowNames) <- c()
-    SupraAdjacencyMatrix <- (1-delta)*(bdiag(unlist(Layers_List)))
-    colnames(SupraAdjacencyMatrix) <-MyColNames
-    rownames(SupraAdjacencyMatrix) <-MyRowNames
-    
-    offdiag <- (delta/(L-1))*Idem_Matrix
-    
+    Adjacency_Layer
+  })
 
-    i <- seq_len(L)
-    Position_ini_row <- 1 + (i-1)*N
-    Position_end_row <- N + (i-1)*N
-    j <- seq_len(L)
-    Position_ini_col <- 1 + (j-1)*N
-    Position_end_col <- N + (j-1)*N
-    
-    combinations <- expand.grid(seq_len(L), seq_len(L))
-    filtered_combinations <- subset(combinations, Var1 != Var2)
-
-    message("Modifying matrix...")
-    modified_matrices <- foreach(column = seq_len(L), .combine = 'cbind') %dopar% {
-        # get rows that match the 
-        column_mask_for_rows <- filtered_combinations$Var2 == column
-        matching_rows <- filtered_combinations[column_mask_for_rows, ]
-
-        matching_layers <- matching_rows$Var1
-        col_ini =  Position_ini_col[column]
-        col_end =  Position_end_col[column]
-
-        modified_matrix <- SupraAdjacencyMatrix[, col_ini:col_end]
-
-
-        col_vector <- c()
-        row_vector <- c()
-        for (sub_layer in matching_layers){
-            row_ini = Position_ini_row[sub_layer]
-            row_end = Position_end_row[sub_layer]
-            row_vector <- c(row_vector, row_ini:row_end)
-            col_vector <- c(col_vector, col_ini:col_end)
-        }
-
-        col_vector <- col_vector - (col_ini -1) 
-
-        modified_vectors <- cbind(row_vector, col_vector)
-        modified_matrix[modified_vectors] <- unique(offdiag[offdiag>0]) # this is scalar... ought to be 1U
-
-        return(drop0(modified_matrix))
-
-    }
-    SupraAdjacencyMatrix = modified_matrices
-
-    stopCluster(cl)
-
+  ## We impose delta=0 in the monoplex case.
+  if (L == 1) {
+    SupraAdjacencyMatrix <- bdiag(unlist(Layers_List))
     SupraAdjacencyMatrix <- as(SupraAdjacencyMatrix, "dgCMatrix")
-
     return(SupraAdjacencyMatrix)
+  }
+
+  cl <- makeCluster(detectCores())
+
+  ## IDEM_MATRIX.
+  Idem_Matrix <- Matrix::Diagonal(N, x = 1)
+
+  MyColNames <- unlist(lapply(Layers_List, function (x) unlist(colnames(x))))
+  MyRowNames <- unlist(lapply(Layers_List, function (x) unlist(rownames(x))))
+  names(MyColNames) <- c()
+  names(MyRowNames) <- c()
+  SupraAdjacencyMatrix <- (1-delta)*(bdiag(unlist(Layers_List)))
+  colnames(SupraAdjacencyMatrix) <- MyColNames
+  rownames(SupraAdjacencyMatrix) <- MyRowNames
+
+  offdiag <- (delta/(L-1))*Idem_Matrix
+
+  i <- seq_len(L)
+  Position_ini_row <- 1 + (i - 1) * N
+  Position_end_row <- N + (i - 1) * N
+  j <- seq_len(L)
+  Position_ini_col <- 1 + (j - 1) * N
+  Position_end_col <- N + (j - 1) * N
+
+  combinations <- expand.grid(seq_len(L), seq_len(L))
+  filtered_combinations <- subset(combinations, Var1 != Var2)
+
+  message("Modifying matrix...")
+  modified_matrices <- foreach(column = seq_len(L), .combine = 'cbind') %dopar% {
+      # get rows that match the 
+      column_mask_for_rows <- filtered_combinations$Var2 == column
+      matching_rows <- filtered_combinations[column_mask_for_rows, ]
+
+      matching_layers <- matching_rows$Var1
+      col_ini =  Position_ini_col[column]
+      col_end =  Position_end_col[column]
+
+      modified_matrix <- SupraAdjacencyMatrix[, col_ini:col_end]
+
+
+      col_vector <- c()
+      row_vector <- c()
+      for (sub_layer in matching_layers){
+          row_ini = Position_ini_row[sub_layer]
+          row_end = Position_end_row[sub_layer]
+          row_vector <- c(row_vector, row_ini:row_end)
+          col_vector <- c(col_vector, col_ini:col_end)
+      }
+
+      col_vector <- col_vector - (col_ini -1) 
+
+      modified_vectors <- cbind(row_vector, col_vector)
+      modified_matrix[modified_vectors] <- unique(offdiag[offdiag>0]) # this is scalar... ought to be 1U
+
+      return(drop0(modified_matrix))
+
+  }
+  SupraAdjacencyMatrix = modified_matrices
+
+  stopCluster(cl)
+
+  SupraAdjacencyMatrix <- as(SupraAdjacencyMatrix, "dgCMatrix")
+
+  return(SupraAdjacencyMatrix)
 }
 
 ## Roxy Documentation comments
@@ -179,16 +180,16 @@ compute.adjacency.matrix <- function(x,delta = 0.5)
 
 normalize.multiplex.adjacency <- function(x)
 {
-    if (!is(x,"dgCMatrix")){
-        stop("Not a dgCMatrix object of Matrix package")
-    }
-    
-    column_sums <- Matrix::colSums(x, na.rm = FALSE, dims = 1, sparseResult = FALSE)
-    column_sums_masked <- column_sums[ column_sums != 0 ]
-    mask_names <- names(column_sums_masked)
-    
-    x[, mask_names] <- t(t(x)[mask_names, ] / column_sums_masked)
-    x
+  if (!is(x,"dgCMatrix")){
+      stop("Not a dgCMatrix object of Matrix package")
+  }
+  
+  column_sums <- Matrix::colSums(x, na.rm = FALSE, dims = 1, sparseResult = FALSE)
+  column_sums_masked <- column_sums[ column_sums != 0 ]
+  mask_names <- names(column_sums_masked)
+  
+  x[, mask_names] <- t(t(x)[mask_names, ] / column_sums_masked)
+  x
 }
 
 ## Roxy Documentation comments
@@ -281,136 +282,136 @@ normalize.multiplex.adjacency <- function(x)
 #'@rdname Random.Walk.Restart.Multiplex
 #'@export
 Random.Walk.Restart.Multiplex <- function(...) {
-    UseMethod("Random.Walk.Restart.Multiplex")
+  UseMethod("Random.Walk.Restart.Multiplex")
 }
 
 #'@rdname Random.Walk.Restart.Multiplex
 #'@export
 Random.Walk.Restart.Multiplex.default <- function(x, MultiplexObject, Seeds, 
-    r=0.7,tau,weights=1,MeanType="Geometric", DispResults="TopScores", ...){
-        
-    ### We control the different values.
-    if (!is(x,"dgCMatrix")){
-        stop("Not a dgCMatrix object of Matrix package")
+  r=0.7,tau,weights=1,MeanType="Geometric", DispResults="TopScores", ...){
+
+  ### We control the different values.
+  if (!is(x,"dgCMatrix")){
+    stop("Not a dgCMatrix object of Matrix package")
+  }
+
+  if (!isMultiplex(MultiplexObject)) {
+    stop("Not a Multiplex object")
+  }
+
+  L <- MultiplexObject$Number_of_Layers
+  N <- MultiplexObject$Number_of_Nodes
+
+  Seeds <- as.character(Seeds)
+  if (length(Seeds) < 1 || length(Seeds) >= N) {
+    stop("The length of the vector containing the seed nodes is not 
+          correct")
+  } else {
+    if (!all(Seeds %in% MultiplexObject$Pool_of_Nodes)){
+      stop("Some of the seeds are not nodes of the network")
     }
-        
-    if (!isMultiplex(MultiplexObject)) {
-        stop("Not a Multiplex object")
+  }
+
+  if (r >= 1 || r <= 0) {
+      stop("Restart partameter should be between 0 and 1")
+  }
+
+  if(missing(tau)){
+    tau <- rep(1,L)/L
+  } else {
+    tau <- as.numeric(tau)
+    if (sum(tau)/L != 1) {
+      stop("The sum of the components of tau divided by the number of 
+            layers should be 1")
     }
-        
-    L <- MultiplexObject$Number_of_Layers
-    N <- MultiplexObject$Number_of_Nodes
-        
-    Seeds <- as.character(Seeds)
-    if (length(Seeds) < 1 | length(Seeds) >= N){
-        stop("The length of the vector containing the seed nodes is not 
-           correct")
+  }
+
+  if(!(MeanType %in% c("Geometric","Arithmetic","Sum"))){
+      stop("The type mean should be Geometric, Arithmetic or Sum")
+  }
+
+  if(!(DispResults %in% c("TopScores","Alphabetic"))){
+      stop("The way to display RWRM results should be TopScores or
+      Alphabetic")
+  }
+
+  ## We define the threshold and the number maximum of iterations for
+  ## the random walker.
+  Threeshold <- 1e-10
+  NetworkSize <- ncol(x)
+
+  ## We initialize the variables to control the flux in the RW algo.
+  residue <- 1
+  iter <- 1
+
+  ## We compute the scores for the different seeds
+  ## Seeds are given initial weightings to bias the walker.
+  Seeds_Score <- get.seed.scoresMultiplex(Seeds,L,tau, weights)
+
+  ## We define the prox_vector(The vector we will move after the first RWR
+  ## iteration. We start from The seed. We have to take in account
+  ## that the walker with restart in some of the Seed nodes, depending on
+  ## the score we gave in that file).
+  prox_vector <- matrix(0,nrow = NetworkSize,ncol=1)
+  prox_vector[which(colnames(x) %in% Seeds_Score[,1])] <- (Seeds_Score[,2])
+  prox_vector  <- prox_vector/sum(prox_vector)
+
+  restart_vector <-  prox_vector
+
+  debug=F
+  dfdebug <- data.frame()  ### remove
+  while(residue >= Threeshold){
+    old_prox_vector <- prox_vector
+    prox_vector <- (1-r)*(x %*% prox_vector) + r*restart_vector
+
+    residue <- sqrt(sum((prox_vector-old_prox_vector)^2))
+    if(debug) {
+      print(iter)
+      dfdebug <- rbind(dfdebug, data.frame(node=rownames(prox_vector), 
+                                           score=prox_vector[,1],
+                                           isSeed = colnames(x) %in% Seeds_Score[,1],
+                                           iter=iter))
+    }
+    iter <- iter + 1;
+  }
+  if (debug) {
+    print("converged!") 
+    write.table(dfdebug,"~/devwork/_SCRATCH/RWRdebug.txt", sep="\t", col.names = T, row.names = F, quote=F)
+  }
+  NodeNames <- character(length = N)
+  Score = numeric(length = N)
+
+  rank_global <- data.frame(NodeNames = NodeNames, Score = Score)
+  rank_global$NodeNames <- gsub("_1$", "", row.names(prox_vector)[seq_len(N)])
+
+  if (MeanType=="Geometric") {
+    rank_global$Score <- geometric.mean(as.vector(prox_vector[,1]),L,N)    
+  } else {
+    if (MeanType=="Arithmetic") {
+      rank_global$Score <- regular.mean(as.vector(prox_vector[,1]),L,N)    
     } else {
-        if (!all(Seeds %in% MultiplexObject$Pool_of_Nodes)){
-            stop("Some of the seeds are not nodes of the network")
-        }
+      rank_global$Score <- sumValues(as.vector(prox_vector[,1]),L,N)    
     }
-        
-    if (r >= 1 || r <= 0) {
-        stop("Restart partameter should be between 0 and 1")
-    }
-        
-    if(missing(tau)){
-        tau <- rep(1,L)/L
-    } else {
-        tau <- as.numeric(tau)
-        if (sum(tau)/L != 1) {
-            stop("The sum of the components of tau divided by the number of 
-             layers should be 1")
-        }
-    }
-        
-    if(!(MeanType %in% c("Geometric","Arithmetic","Sum"))){
-        stop("The type mean should be Geometric, Arithmetic or Sum")
-    }
-        
-    if(!(DispResults %in% c("TopScores","Alphabetic"))){
-        stop("The way to display RWRM results should be TopScores or
-       Alphabetic")
-    }
-        
-    ## We define the threshold and the number maximum of iterations for
-    ## the random walker.
-    Threeshold <- 1e-10
-    NetworkSize <- ncol(x)
-        
-    ## We initialize the variables to control the flux in the RW algo.
-    residue <- 1
-    iter <- 1
-        
-    ## We compute the scores for the different seeds
-    ## Seeds are given initial weightings to bias the walker.
-    Seeds_Score <- get.seed.scoresMultiplex(Seeds,L,tau, weights)
-    
-    ## We define the prox_vector(The vector we will move after the first RWR
-    ## iteration. We start from The seed. We have to take in account
-    ## that the walker with restart in some of the Seed nodes, depending on
-    ## the score we gave in that file).
-    prox_vector <- matrix(0,nrow = NetworkSize,ncol=1)
-    prox_vector[which(colnames(x) %in% Seeds_Score[,1])] <- (Seeds_Score[,2])
-    prox_vector  <- prox_vector/sum(prox_vector)
-    
-    restart_vector <-  prox_vector
-    
-    debug=F
-    dfdebug <- data.frame()  ### remove
-    while(residue >= Threeshold){
-        old_prox_vector <- prox_vector
-        prox_vector <- (1-r)*(x %*% prox_vector) + r*restart_vector
-        
-        residue <- sqrt(sum((prox_vector-old_prox_vector)^2))
-        if(debug) {
-            print(iter)
-            dfdebug <- rbind(dfdebug, data.frame(node=rownames(prox_vector), 
-                                                       score=prox_vector[,1],
-                                                       isSeed = colnames(x) %in% Seeds_Score[,1],
-                                                       iter=iter))
-        }
-        iter <- iter + 1;
-    }
-    if(debug){
-        print("converged!") 
-        write.table(dfdebug,"~/devwork/_SCRATCH/RWRdebug.txt", sep="\t", col.names = T, row.names = F, quote=F)
-    }
-    NodeNames <- character(length = N)
-    Score = numeric(length = N)
-        
-    rank_global <- data.frame(NodeNames = NodeNames, Score = Score)
-    rank_global$NodeNames <- gsub("_1$", "", row.names(prox_vector)[seq_len(N)])
-        
-    if (MeanType=="Geometric"){
-        rank_global$Score <- geometric.mean(as.vector(prox_vector[,1]),L,N)    
-    } else {
-        if (MeanType=="Arithmetic") {
-            rank_global$Score <- regular.mean(as.vector(prox_vector[,1]),L,N)    
-        } else {
-            rank_global$Score <- sumValues(as.vector(prox_vector[,1]),L,N)    
-        }
-    }
-        
-    if (DispResults=="TopScores"){
-        ## We sort the nodes according to their score.
-        Global_results <- 
-            rank_global[with(rank_global, order(-Score, NodeNames)), ]
-            
-        ### We remove the seed nodes from the Ranking and we write the results.
-        Global_results <- 
-            Global_results[which(!Global_results$NodeNames %in% Seeds),]
-    } else {
-        Global_results <- rank_global    
-    }
-        
-    rownames(Global_results) <- c()
-    
-    RWRM_ranking <- list(RWRM_Results = Global_results,Seed_Nodes = Seeds)
-        
-    class(RWRM_ranking) <- "RWRM_Results"
-    return(RWRM_ranking)
+  }
+
+  if (DispResults=="TopScores"){
+    ## We sort the nodes according to their score.
+    Global_results <-
+        rank_global[with(rank_global, order(-Score, NodeNames)), ]
+
+    ### We remove the seed nodes from the Ranking and we write the results.
+    Global_results <-
+        Global_results[which(!Global_results$NodeNames %in% Seeds),]
+  } else {
+    Global_results <- rank_global
+  }
+
+  rownames(Global_results) <- c()
+
+  RWRM_ranking <- list(RWRM_Results = Global_results,Seed_Nodes = Seeds)
+
+  class(RWRM_ranking) <- "RWRM_Results"
+  return(RWRM_ranking)
 }
 
 
@@ -419,10 +420,10 @@ Random.Walk.Restart.Multiplex.default <- function(x, MultiplexObject, Seeds,
 #' @export
 print.RWRM_Results <- function(x,...)
 {
-    cat("Top 10 ranked Nodes:\n")
-    print(head(x$RWRM_Results,10))
-    cat("\nSeed Nodes used:\n")
-    print(x$Seed_Nodes)
+  cat("Top 10 ranked Nodes:\n")
+  print(head(x$RWRM_Results,10))
+  cat("\nSeed Nodes used:\n")
+  print(x$Seed_Nodes)
 }
 
 ## Roxy Documentation comments
@@ -487,66 +488,66 @@ print.RWRM_Results <- function(x,...)
 #'@export
 compute.transition.matrix <- function(x,lambda = 0.5, delta1=0.5,delta2=0.5)
 {
-    if (!isMultiplexHet(x)) {
-        stop("Not a Multiplex Heterogeneous object")
-    }
-    
-    if (delta1 > 1 || delta1 <= 0) {
-        stop("Delta1 should be between 0 and 1")
-    }
-    
-    if (delta2 > 1 || delta2 <= 0) {
-        stop("Delta2 should be between 0 and 1")
-    }
-    
-    if (lambda > 1 || lambda <= 0) {
-        stop("Lambda should be between 0 and 1")
-    }
-    
-    Number_Nodes_1 <- x$Multiplex1$Number_of_Nodes_Multiplex
-    Number_Layers_1 <- x$Multiplex1$Number_of_Layers
-    Number_Nodes_2 <- x$Multiplex2$Number_of_Nodes_Multiplex
-    Number_Layers_2 <- x$Multiplex2$Number_of_Layers
-    SupraBipartiteMatrix <- x$BipartiteNetwork
-    
-    message("Computing adjacency matrix of the first Multiplex network...")
-    AdjMatrix_Multiplex1 <- compute.adjacency.matrix(x$Multiplex1,delta1)
-    
-    message("Computing adjacency matrix of the second Multiplex network...")
-    ## We have to sort the adjacency matrix
-    AdjMatrix_Multiplex2 <- compute.adjacency.matrix(x$Multiplex2,delta2)
-    
-    ## Transition Matrix for the inter-subnetworks links
-    message("Computing inter-subnetworks transitions...")
-    Transition_Multiplex1_Multiplex2 <- 
-        get.transition.multiplex1.multiplex2(Number_Nodes_1,Number_Layers_1,
-            Number_Nodes_2,Number_Layers_2,SupraBipartiteMatrix,lambda)
-    
-    Transition_Multiplex2_Multiplex1 <- 
-        get.transition.multiplex2.multiplex1(Number_Nodes_1,Number_Layers_1,
-            Number_Nodes_2, Number_Layers_2, SupraBipartiteMatrix,lambda)
-    
-    ## Transition Matrix for the intra-subnetworks links
-    message("Computing intra-subnetworks transitions...")
-    Transition_Multiplex_Network1 <- 
-        get.transition.multiplex(Number_Nodes_1, Number_Layers_1, lambda, 
-            AdjMatrix_Multiplex1,SupraBipartiteMatrix)
-    Transition_Multiplex_Network2 <- 
-        get.transition.multiplex(Number_Nodes_2,Number_Layers_2, lambda,
-            t(AdjMatrix_Multiplex2),t(SupraBipartiteMatrix))
-    
-    ## We generate the global transiction matrix and we return it.
-    message("Combining inter e intra layer probabilities into the global 
-          Transition Matix")
-    Transition_Multiplex_Heterogeneous_Matrix_1 <-
-        cbind(Transition_Multiplex_Network1, Transition_Multiplex1_Multiplex2)
-    Transition_Multiplex_Heterogeneous_Matrix_2 <-
-        cbind(Transition_Multiplex2_Multiplex1, Transition_Multiplex_Network2)
-    Transition_Multiplex_Heterogeneous_Matrix <-
-        rbind(Transition_Multiplex_Heterogeneous_Matrix_1,
-              Transition_Multiplex_Heterogeneous_Matrix_2)
-    
-    return(Transition_Multiplex_Heterogeneous_Matrix)
+  if (!isMultiplexHet(x)) {
+      stop("Not a Multiplex Heterogeneous object")
+  }
+  
+  if (delta1 > 1 || delta1 <= 0) {
+      stop("Delta1 should be between 0 and 1")
+  }
+  
+  if (delta2 > 1 || delta2 <= 0) {
+      stop("Delta2 should be between 0 and 1")
+  }
+  
+  if (lambda > 1 || lambda <= 0) {
+      stop("Lambda should be between 0 and 1")
+  }
+  
+  Number_Nodes_1 <- x$Multiplex1$Number_of_Nodes_Multiplex
+  Number_Layers_1 <- x$Multiplex1$Number_of_Layers
+  Number_Nodes_2 <- x$Multiplex2$Number_of_Nodes_Multiplex
+  Number_Layers_2 <- x$Multiplex2$Number_of_Layers
+  SupraBipartiteMatrix <- x$BipartiteNetwork
+  
+  message("Computing adjacency matrix of the first Multiplex network...")
+  AdjMatrix_Multiplex1 <- compute.adjacency.matrix(x$Multiplex1,delta1)
+  
+  message("Computing adjacency matrix of the second Multiplex network...")
+  ## We have to sort the adjacency matrix
+  AdjMatrix_Multiplex2 <- compute.adjacency.matrix(x$Multiplex2,delta2)
+  
+  ## Transition Matrix for the inter-subnetworks links
+  message("Computing inter-subnetworks transitions...")
+  Transition_Multiplex1_Multiplex2 <- 
+      get.transition.multiplex1.multiplex2(Number_Nodes_1,Number_Layers_1,
+          Number_Nodes_2,Number_Layers_2,SupraBipartiteMatrix,lambda)
+  
+  Transition_Multiplex2_Multiplex1 <- 
+      get.transition.multiplex2.multiplex1(Number_Nodes_1,Number_Layers_1,
+          Number_Nodes_2, Number_Layers_2, SupraBipartiteMatrix,lambda)
+  
+  ## Transition Matrix for the intra-subnetworks links
+  message("Computing intra-subnetworks transitions...")
+  Transition_Multiplex_Network1 <- 
+      get.transition.multiplex(Number_Nodes_1, Number_Layers_1, lambda, 
+          AdjMatrix_Multiplex1,SupraBipartiteMatrix)
+  Transition_Multiplex_Network2 <- 
+      get.transition.multiplex(Number_Nodes_2,Number_Layers_2, lambda,
+          t(AdjMatrix_Multiplex2),t(SupraBipartiteMatrix))
+  
+  ## We generate the global transiction matrix and we return it.
+  message("Combining inter e intra layer probabilities into the global 
+        Transition Matix")
+  Transition_Multiplex_Heterogeneous_Matrix_1 <-
+      cbind(Transition_Multiplex_Network1, Transition_Multiplex1_Multiplex2)
+  Transition_Multiplex_Heterogeneous_Matrix_2 <-
+      cbind(Transition_Multiplex2_Multiplex1, Transition_Multiplex_Network2)
+  Transition_Multiplex_Heterogeneous_Matrix <-
+      rbind(Transition_Multiplex_Heterogeneous_Matrix_1,
+            Transition_Multiplex_Heterogeneous_Matrix_2)
+  
+  return(Transition_Multiplex_Heterogeneous_Matrix)
 }
 
 ## Roxy Documentation comments
@@ -677,191 +678,191 @@ compute.transition.matrix <- function(x,lambda = 0.5, delta1=0.5,delta2=0.5)
 #'@rdname Random.Walk.Restart.MultiplexHet
 #'@export
 Random.Walk.Restart.MultiplexHet <- function(...){
-    UseMethod("Random.Walk.Restart.MultiplexHet")
+  UseMethod("Random.Walk.Restart.MultiplexHet")
 }
 
 #'@rdname Random.Walk.Restart.MultiplexHet
 #'@export
 Random.Walk.Restart.MultiplexHet.default <- function(x, MultiplexHet_Object, 
-    Multiplex1_Seeds,Multiplex2_Seeds, r=0.7,tau1,tau2,eta=0.5,
-    MeanType="Geometric", DispResults="TopScores",...){
-        
-    ## We control the different values.
-    if (!"dgCMatrix" %in% class(x)){
-        stop("Not a dgCMatrix object of Matrix package")
-    }
-    
-    if (!isMultiplexHet(MultiplexHet_Object)) {
-        stop("Not a Multiplex Heterogeneous object")
-    }
-        
-    NumberLayers1 <- MultiplexHet_Object$Multiplex1$Number_of_Layers
-    NumberNodes1 <- MultiplexHet_Object$Multiplex1$Number_of_Nodes_Multiplex
-    NumberLayers2 <- MultiplexHet_Object$Multiplex2$Number_of_Layers
-    NumberNodes2 <- MultiplexHet_Object$Multiplex2$Number_of_Nodes_Multiplex
-        
-    All_nodes_Multiplex1 <- MultiplexHet_Object$Multiplex1$Pool_of_Nodes
-    All_nodes_Multiplex2 <- MultiplexHet_Object$Multiplex2$Pool_of_Nodes
-        
-    MultiplexSeeds1 <- as.character(Multiplex1_Seeds)
-    MultiplexSeeds2 <- as.character(Multiplex2_Seeds)
-        
-    if (length(MultiplexSeeds1) < 1 & length(MultiplexSeeds2) < 1){
-        stop("You did not provided any seeds")
-    } else {
-        if (length(MultiplexSeeds1) >= NumberNodes1 | length(MultiplexSeeds2) >= 
-            NumberNodes2){
-            stop("The length of some of the vectors containing the seed nodes 
-            is not correct")
-        }  else {
-            if (!all(MultiplexSeeds1 %in% All_nodes_Multiplex1)){
-                stop("Some of the  input seeds are not nodes of the first 
-               input network")
-            } else {
-                if (!all(All_nodes_Multiplex2 %in% All_nodes_Multiplex2)){
-                    stop("Some of the inputs seeds are not nodes of the second
-                        input network")
-                }
-            }
-        }
-    }
-        
-    if (r >= 1 || r <= 0) {
-        stop("Restart partameter should be between 0 and 1")
-    }
-        
-    if (eta >= 1 || eta <= 0) {
-        stop("Eta partameter should be between 0 and 1")
-    }
-        
-    if(missing(tau1)){
-        tau1 <- rep(1,NumberLayers1)/NumberLayers1
-    } else {
-        tau1 <- as.numeric(tau1)
-        if (sum(tau1)/NumberLayers1 != 1) {
-            stop("The sum of the components of tau divided by the number of 
-                layers should be 1")}
-    }
-        
-    if(missing(tau2)){
-        tau2 <- rep(1,NumberLayers2)/NumberLayers2
-    } else {
-        tau2 <- as.numeric(tau2)
-        if (sum(tau2)/NumberLayers2 != 1) {
-            stop("The sum of the components of tau divided by the number of 
-            layers should be 1")}
-    }
-        
-    if(!(MeanType %in% c("Geometric","Arithmetic","Sum"))){
-        stop("The type mean should be Geometric, Arithmetic or Sum")
-    }
-        
-    if(!(DispResults %in% c("TopScores","Alphabetic"))){
-        stop("The way to display RWRM results should be TopScores or
-       Alphabetic")
-    }
-        
-    ## We define the threshold and the number maximum of iterations
-    ## for the random walker.
-    Threeshold <- 1e-10
-    NetworkSize <- ncol(x)
-        
-    ## We initialize the variables to control the flux in the RW algo.
-    residue <- 1
-    iter <- 1
-        
-    ## We compute the scores for the different seeds.
-    Seeds_Score <- get.seed.scores.multHet(Multiplex1_Seeds, Multiplex2_Seeds,eta,
-        NumberLayers1,NumberLayers2,tau1,tau2)
-        
-    ## We define the prox_vector(The vector we will move after the first
-    ## RWR iteration. We start from The seed. We have to take in account
-    ## that the walker with restart in some of the Seed genes,
-    ## depending on the score we gave in that file).
-    prox_vector <- matrix(0,nrow = NetworkSize,ncol=1)
-    
-    prox_vector[which(colnames(x) %in% Seeds_Score[,1])] <- (Seeds_Score[,2])
-        
-    prox_vector  <- prox_vector/sum(prox_vector)
-    restart_vector <-  prox_vector
-        
-    while(residue >= Threeshold){
-            
-        old_prox_vector <- prox_vector
-        prox_vector <- (1-r)*(x %*% prox_vector) + r*restart_vector
-        residue <- sqrt(sum((prox_vector-old_prox_vector)^2))
-        iter <- iter + 1;
-    }
-        
-    IndexSep <- NumberNodes1*NumberLayers1
-    prox_vector_1 <- prox_vector[1:IndexSep,]
-    prox_vector_2 <- prox_vector[(IndexSep+1):nrow(prox_vector),]
-        
-    NodeNames1 <- gsub("_1$", "",names(prox_vector_1)[seq_len(NumberNodes1)])
-    NodeNames2 <- gsub("_1$", "",names(prox_vector_2)[seq_len(NumberNodes2)])
-        
-    if (MeanType=="Geometric"){
-        rank_global1 <- geometric.mean(prox_vector_1,NumberLayers1,NumberNodes1)    
-        rank_global2 <- geometric.mean(prox_vector_2,NumberLayers2,NumberNodes2)   
-    } else {
-        if (MeanType=="Arithmetic") {
-            rank_global1 <- regular.mean(prox_vector_1,NumberLayers1,NumberNodes1)    
-            rank_global2 <- regular.mean(prox_vector_2,NumberLayers2,NumberNodes2)     
-        } else {
-            rank_global1 <- sumValues(prox_vector_1,NumberLayers1,NumberNodes1)    
-            rank_global2 <- sumValues(prox_vector_2,NumberLayers2,NumberNodes2) 
-        }
-    }
-        
-    Global_results <- data.frame(NodeNames = c(NodeNames1,NodeNames2), 
-        Score = c(rank_global1,rank_global2))
-    
-    Multiplex1_results <-data.frame(NodeNames = NodeNames1,Score = rank_global1)
-    Multiplex2_results <-data.frame(NodeNames = NodeNames2,Score = rank_global2)
-    Seeds <- c(Multiplex1_Seeds, Multiplex2_Seeds)
-    
-    if (DispResults=="TopScores"){
-        ## We sort the nodes according to their score.
-        Global_results <- 
-            Global_results[with(Global_results, order(-Score, NodeNames)), ]
-        Multiplex1_results <-
-            Multiplex1_results[with(Multiplex1_results, order(-Score, NodeNames)),] 
-        Multiplex2_results <-
-            Multiplex2_results[with(Multiplex2_results, order(-Score, NodeNames)),] 
-        
-        ### We remove the seed from the individual networks 
-        Multiplex1_results <- 
-            Multiplex1_results[which(!Multiplex1_results$NodeNames %in% Seeds),]
-        Multiplex2_results <- 
-            Multiplex2_results[which(!Multiplex2_results$NodeNames %in% Seeds),]
-        
-        } else {
-            Global_results <- Global_results
-            Multiplex1_results <- Multiplex1_results
-            Multiplex2_results <- Multiplex2_results
-        }
-        
-    rownames(Global_results) <- c()
-        
-    RWRMH_ranking <- list(RWRMH_GlobalResults = Global_results, 
-        RWRMH_Multiplex1 = Multiplex1_results, 
-        RWRMH_Multiplex2 = Multiplex2_results,
-        Seed_Nodes = Seeds)
-        
-    class(RWRMH_ranking) <- "RWRMH_Results"
-    return(RWRMH_ranking)
+  Multiplex1_Seeds,Multiplex2_Seeds, r=0.7,tau1,tau2,eta=0.5,
+  MeanType="Geometric", DispResults="TopScores",...){
+      
+  ## We control the different values.
+  if (!"dgCMatrix" %in% class(x)){
+      stop("Not a dgCMatrix object of Matrix package")
+  }
+  
+  if (!isMultiplexHet(MultiplexHet_Object)) {
+      stop("Not a Multiplex Heterogeneous object")
+  }
+      
+  NumberLayers1 <- MultiplexHet_Object$Multiplex1$Number_of_Layers
+  NumberNodes1 <- MultiplexHet_Object$Multiplex1$Number_of_Nodes_Multiplex
+  NumberLayers2 <- MultiplexHet_Object$Multiplex2$Number_of_Layers
+  NumberNodes2 <- MultiplexHet_Object$Multiplex2$Number_of_Nodes_Multiplex
+      
+  All_nodes_Multiplex1 <- MultiplexHet_Object$Multiplex1$Pool_of_Nodes
+  All_nodes_Multiplex2 <- MultiplexHet_Object$Multiplex2$Pool_of_Nodes
+      
+  MultiplexSeeds1 <- as.character(Multiplex1_Seeds)
+  MultiplexSeeds2 <- as.character(Multiplex2_Seeds)
+      
+  if (length(MultiplexSeeds1) < 1 & length(MultiplexSeeds2) < 1){
+      stop("You did not provided any seeds")
+  } else {
+      if (length(MultiplexSeeds1) >= NumberNodes1 | length(MultiplexSeeds2) >= 
+          NumberNodes2){
+          stop("The length of some of the vectors containing the seed nodes 
+          is not correct")
+      }  else {
+          if (!all(MultiplexSeeds1 %in% All_nodes_Multiplex1)){
+              stop("Some of the  input seeds are not nodes of the first 
+              input network")
+          } else {
+              if (!all(All_nodes_Multiplex2 %in% All_nodes_Multiplex2)){
+                  stop("Some of the inputs seeds are not nodes of the second
+                      input network")
+              }
+          }
+      }
+  }
+      
+  if (r >= 1 || r <= 0) {
+      stop("Restart partameter should be between 0 and 1")
+  }
+      
+  if (eta >= 1 || eta <= 0) {
+      stop("Eta partameter should be between 0 and 1")
+  }
+      
+  if(missing(tau1)){
+      tau1 <- rep(1,NumberLayers1)/NumberLayers1
+  } else {
+      tau1 <- as.numeric(tau1)
+      if (sum(tau1)/NumberLayers1 != 1) {
+          stop("The sum of the components of tau divided by the number of 
+              layers should be 1")}
+  }
+      
+  if(missing(tau2)){
+      tau2 <- rep(1,NumberLayers2)/NumberLayers2
+  } else {
+      tau2 <- as.numeric(tau2)
+      if (sum(tau2)/NumberLayers2 != 1) {
+          stop("The sum of the components of tau divided by the number of 
+          layers should be 1")}
+  }
+      
+  if(!(MeanType %in% c("Geometric","Arithmetic","Sum"))){
+      stop("The type mean should be Geometric, Arithmetic or Sum")
+  }
+      
+  if(!(DispResults %in% c("TopScores","Alphabetic"))){
+      stop("The way to display RWRM results should be TopScores or
+      Alphabetic")
+  }
+      
+  ## We define the threshold and the number maximum of iterations
+  ## for the random walker.
+  Threeshold <- 1e-10
+  NetworkSize <- ncol(x)
+      
+  ## We initialize the variables to control the flux in the RW algo.
+  residue <- 1
+  iter <- 1
+      
+  ## We compute the scores for the different seeds.
+  Seeds_Score <- get.seed.scores.multHet(Multiplex1_Seeds, Multiplex2_Seeds,eta,
+      NumberLayers1,NumberLayers2,tau1,tau2)
+      
+  ## We define the prox_vector(The vector we will move after the first
+  ## RWR iteration. We start from The seed. We have to take in account
+  ## that the walker with restart in some of the Seed genes,
+  ## depending on the score we gave in that file).
+  prox_vector <- matrix(0,nrow = NetworkSize,ncol=1)
+  
+  prox_vector[which(colnames(x) %in% Seeds_Score[,1])] <- (Seeds_Score[,2])
+      
+  prox_vector  <- prox_vector/sum(prox_vector)
+  restart_vector <-  prox_vector
+      
+  while(residue >= Threeshold){
+          
+      old_prox_vector <- prox_vector
+      prox_vector <- (1-r)*(x %*% prox_vector) + r*restart_vector
+      residue <- sqrt(sum((prox_vector-old_prox_vector)^2))
+      iter <- iter + 1;
+  }
+      
+  IndexSep <- NumberNodes1*NumberLayers1
+  prox_vector_1 <- prox_vector[1:IndexSep,]
+  prox_vector_2 <- prox_vector[(IndexSep+1):nrow(prox_vector),]
+      
+  NodeNames1 <- gsub("_1$", "",names(prox_vector_1)[seq_len(NumberNodes1)])
+  NodeNames2 <- gsub("_1$", "",names(prox_vector_2)[seq_len(NumberNodes2)])
+      
+  if (MeanType=="Geometric"){
+      rank_global1 <- geometric.mean(prox_vector_1,NumberLayers1,NumberNodes1)    
+      rank_global2 <- geometric.mean(prox_vector_2,NumberLayers2,NumberNodes2)   
+  } else {
+      if (MeanType=="Arithmetic") {
+          rank_global1 <- regular.mean(prox_vector_1,NumberLayers1,NumberNodes1)    
+          rank_global2 <- regular.mean(prox_vector_2,NumberLayers2,NumberNodes2)     
+      } else {
+          rank_global1 <- sumValues(prox_vector_1,NumberLayers1,NumberNodes1)    
+          rank_global2 <- sumValues(prox_vector_2,NumberLayers2,NumberNodes2) 
+      }
+  }
+      
+  Global_results <- data.frame(NodeNames = c(NodeNames1,NodeNames2), 
+      Score = c(rank_global1,rank_global2))
+  
+  Multiplex1_results <-data.frame(NodeNames = NodeNames1,Score = rank_global1)
+  Multiplex2_results <-data.frame(NodeNames = NodeNames2,Score = rank_global2)
+  Seeds <- c(Multiplex1_Seeds, Multiplex2_Seeds)
+  
+  if (DispResults=="TopScores"){
+      ## We sort the nodes according to their score.
+      Global_results <- 
+          Global_results[with(Global_results, order(-Score, NodeNames)), ]
+      Multiplex1_results <-
+          Multiplex1_results[with(Multiplex1_results, order(-Score, NodeNames)),] 
+      Multiplex2_results <-
+          Multiplex2_results[with(Multiplex2_results, order(-Score, NodeNames)),] 
+      
+      ### We remove the seed from the individual networks 
+      Multiplex1_results <- 
+          Multiplex1_results[which(!Multiplex1_results$NodeNames %in% Seeds),]
+      Multiplex2_results <- 
+          Multiplex2_results[which(!Multiplex2_results$NodeNames %in% Seeds),]
+      
+      } else {
+          Global_results <- Global_results
+          Multiplex1_results <- Multiplex1_results
+          Multiplex2_results <- Multiplex2_results
+      }
+      
+  rownames(Global_results) <- c()
+      
+  RWRMH_ranking <- list(RWRMH_GlobalResults = Global_results, 
+      RWRMH_Multiplex1 = Multiplex1_results, 
+      RWRMH_Multiplex2 = Multiplex2_results,
+      Seed_Nodes = Seeds)
+      
+  class(RWRMH_ranking) <- "RWRMH_Results"
+  return(RWRMH_ranking)
 }
 
 #' @method print RWRMH_Results
 #' @export
 print.RWRMH_Results <- function(x,...)
 {
-    cat("Top 10 ranked global nodes:\n")
-    print(head(x$RWRMH_GlobalResults,10))
-    cat("\nTop 10 ranked nodes from the first Multiplex:\n")
-    print(head(x$RWRMH_Multiplex1,10))
-    cat("\nTop 10 ranked nodes from the second Multiplex:\n")
-    print(head(x$RWRMH_Multiplex2,10))
-    cat("\nSeeds used:\n")
-    print(x$Seed_Nodes)
+  cat("Top 10 ranked global nodes:\n")
+  print(head(x$RWRMH_GlobalResults,10))
+  cat("\nTop 10 ranked nodes from the first Multiplex:\n")
+  print(head(x$RWRMH_Multiplex1,10))
+  cat("\nTop 10 ranked nodes from the second Multiplex:\n")
+  print(head(x$RWRMH_Multiplex2,10))
+  cat("\nSeeds used:\n")
+  print(x$Seed_Nodes)
 }

--- a/R/RWRandMatrices.R
+++ b/R/RWRandMatrices.R
@@ -516,7 +516,6 @@ compute.transition.matrix <- function(x,lambda = 0.5, delta1=0.5,delta2=0.5)
   message("Computing adjacency matrix of the second Multiplex network...")
   ## We have to sort the adjacency matrix
   AdjMatrix_Multiplex2 <- compute.adjacency.matrix(x$Multiplex2,delta2)
-  
   ## Transition Matrix for the inter-subnetworks links
   message("Computing inter-subnetworks transitions...")
   Transition_Multiplex1_Multiplex2 <- 
@@ -547,7 +546,7 @@ compute.transition.matrix <- function(x,lambda = 0.5, delta1=0.5,delta2=0.5)
       rbind(Transition_Multiplex_Heterogeneous_Matrix_1,
             Transition_Multiplex_Heterogeneous_Matrix_2)
   
-  return(Transition_Multiplex_Heterogeneous_Matrix)
+  return(t(Transition_Multiplex_Heterogeneous_Matrix))
 }
 
 ## Roxy Documentation comments

--- a/R/RWRandMatrices.R
+++ b/R/RWRandMatrices.R
@@ -62,7 +62,7 @@ compute.adjacency.matrix <- function(x,delta = 0.5) {
   counter <- 0
   Layers_List <- lapply(x[Layers_Names],function(x){
 
-    counter <- counter + 1
+    counter <<- counter + 1
     if (is_weighted(x)) { 
       Adjacency_Layer <- as_adjacency_matrix(x, sparse = TRUE, attr = "weight")
     } else {

--- a/R/RWRandMatrices.R
+++ b/R/RWRandMatrices.R
@@ -110,6 +110,7 @@ compute.adjacency.matrix <- function(x,delta = 0.5)
     combinations <- expand.grid(seq_len(L), seq_len(L))
     filtered_combinations <- subset(combinations, Var1 != Var2)
 
+    message("Modifying matrix...")
     modified_matrices <- foreach(column = seq_len(L), .combine = 'cbind') %dopar% {
         # get rows that match the 
         column_mask_for_rows <- filtered_combinations$Var2 == column


### PR DESCRIPTION
Updated "compute.adjacency.matrix" function for monoplexes. Previously, an identity matrix was created for both monoplexes and multiplexed to represent edges between layers. For monoplexes, the matrix was scaled by "Inf" and resulted in the creation of a dense matrix. For larger number of nodes, this matrix can be several Gbs. Now, the identify matrix is only created for multiplexes.